### PR TITLE
fix: fix race condition which cause scrolling issue

### DIFF
--- a/packages/components/src/array-table/index.tsx
+++ b/packages/components/src/array-table/index.tsx
@@ -372,7 +372,9 @@ const InternalArrayTable: ReactFC<TableProps<any>> = observer(
               }}
               onSortEnd={(event) => {
                 const { oldIndex, newIndex } = event
-                field.move(oldIndex, newIndex)
+                window.requestAnimationFrame(() => {
+                  field.move(oldIndex, newIndex)
+                })
               }}
               className={cls(`${prefixCls}-sort-helper`, props.className)}
             >


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/master/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `master`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
Issue: When a user drags an item outside the visible area with autoScroll enabled, the sort handle causes the page to scroll to the top after the user stops the action.

Result: I fixed the race condition between the field.move function and any animations or updates that may be happening concurrently, which prevented the issue from persisting.
