### PR TITLE
fix: TreeSelect只读态判断fieldNames设置

### DIFF
--- a/packages/components/src/preview-text/index.tsx
+++ b/packages/components/src/preview-text/index.tsx
@@ -169,9 +169,10 @@ const TreeSelect: React.FC<React.PropsWithChildren<TreeSelectProps<any>>> =
       dataSource: any[],
       treeNodeLabelProp?: string
     ) => {
+      const valueKey = props.fieldNames?.value || 'value'
       for (let i = 0; i < dataSource?.length; i++) {
         const item = dataSource[i]
-        if (item?.value === value) {
+        if (item?.[valueKey] === value) {
           return item?.label ?? item[treeNodeLabelProp as string]
         } else {
           const childLabel = findLabel(value, item?.children, treeNodeLabelProp)


### PR DESCRIPTION
现在TreeSelect只读态直接按value去取label的值的，没有判断fieldNames设置
改成根据fieldNames设置获取