### PR TITLE
fix: 修复ArrayTable筛选后, index找寻逻辑错误导致过滤后的数据状态异常

### DIFF
--- a/docs/components/ArrayTable.zh-CN.md
+++ b/docs/components/ArrayTable.zh-CN.md
@@ -83,7 +83,18 @@ export default () => {
             </SchemaField.Void>
             <SchemaField.Void
               x-component="ArrayTable.Column"
-              x-component-props={{ title: 'A2', width: 200 }}
+              x-component-props={{
+                title: 'A2',
+                width: 200,
+                filters: [
+                  { text: 'a', value: 'a' },
+                  { text: 'aa', value: 'aa' },
+                  { text: 'b', value: 'b' },
+                ],
+                onFilter(value, record) {
+                  return record.a2 === value
+                },
+              }}
             >
               <SchemaField.String
                 x-decorator="FormItem"


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] If you've added code that should be tested, add tests!
- [ ] Fork the repo and create your branch from `master` or `master`.
- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/master/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

问题：ArrayTable中判断行索引index的逻辑异常，导致筛选后的行数据，状态异常 。
原本使用的
```
render(value,record) {
   // dataSource是一个代理对象数组
   // record 不是原数据的引用了，就是个普通对象， index始终为-1
   const index = dataSource.indexOf(record);
}
```


 https://github.com/alibaba/formily/issues/4146


## What have you changed?
对dataSource 中添加了一个__index__属性来保存行索引。
查看中文下的deploy preview
![image](https://github.com/formilyjs/antd/assets/26474133/bb1dc7a8-04b6-48b8-a998-d57ac36d7305)



