### PR TITLE
fix(components): 🩹 replace defaultProps by default parameters

### DIFF
--- a/packages/components/src/__builtins__/portal.tsx
+++ b/packages/components/src/__builtins__/portal.tsx
@@ -11,8 +11,9 @@ const PortalMap = observable(new Map<string | symbol, React.ReactNode>())
 
 export const createPortalProvider = (id: string | symbol) => {
   const Portal: ReactFC<IPortalProps> = (props) => {
-    if (props.id && !PortalMap.has(props.id)) {
-      PortalMap.set(props.id, null)
+    const portalId = props.id ?? id
+    if (portalId && !PortalMap.has(portalId)) {
+      PortalMap.set(portalId, null)
     }
 
     return (
@@ -20,8 +21,8 @@ export const createPortalProvider = (id: string | symbol) => {
         {props.children}
         <Observer>
           {() => {
-            if (!props.id) return <></>
-            const portal = PortalMap.get(props.id)
+            if (portalId!) return <></>
+            const portal = PortalMap.get(portalId)
             if (portal) return createPortal(portal, document.body)
             return <></>
           }}
@@ -29,9 +30,7 @@ export const createPortalProvider = (id: string | symbol) => {
       </Fragment>
     )
   }
-  Portal.defaultProps = {
-    id,
-  }
+
   return Portal
 }
 

--- a/packages/components/src/array-collapse/index.tsx
+++ b/packages/components/src/array-collapse/index.tsx
@@ -79,10 +79,7 @@ const InternalArrayCollapse: ReactFC<IArrayCollapseProps> = observer(
     const field = useField<ArrayField>()
     const dataSource = Array.isArray(field.value) ? field.value : []
     const [activeKeys, setActiveKeys] = useState<number[]>(
-      takeDefaultActiveKeys(
-        dataSource.length,
-        props.defaultOpenPanelCount as number
-      )
+      takeDefaultActiveKeys(dataSource.length, props.defaultOpenPanelCount ?? 5)
     )
     const schema = useFieldSchema()
     const prefixCls = usePrefixCls('formily-array-collapse', props)
@@ -93,7 +90,7 @@ const InternalArrayCollapse: ReactFC<IArrayCollapseProps> = observer(
         setActiveKeys(
           takeDefaultActiveKeys(
             dataSource.length,
-            props.defaultOpenPanelCount as number
+            props.defaultOpenPanelCount ?? 5
           )
         )
       }
@@ -250,9 +247,5 @@ export const ArrayCollapse = Object.assign(
   }
 )
 ArrayCollapse.displayName = 'ArrayCollapse'
-
-ArrayCollapse.defaultProps = {
-  defaultOpenPanelCount: 5,
-}
 
 export default ArrayCollapse

--- a/packages/components/src/form-button-group/index.tsx
+++ b/packages/components/src/form-button-group/index.tsx
@@ -59,7 +59,7 @@ function getDefaultBackground() {
 }
 
 export const FormButtonGroup: ComposedButtonGroup = ({
-  align,
+  align = 'left',
   gutter,
   ...props
 }) => {
@@ -85,10 +85,6 @@ export const FormButtonGroup: ComposedButtonGroup = ({
   )
 }
 
-FormButtonGroup.defaultProps = {
-  align: 'left',
-}
-
 FormButtonGroup.FormItem = ({ gutter, ...props }) => {
   return (
     <BaseItem
@@ -111,7 +107,7 @@ FormButtonGroup.FormItem = ({ gutter, ...props }) => {
   )
 }
 
-FormButtonGroup.Sticky = ({ align, ...props }) => {
+FormButtonGroup.Sticky = ({ align = 'left', ...props }) => {
   const ref = useRef(null)
   const [color, setColor] = useState('transparent')
   const prefixCls = usePrefixCls('formily-button-group')
@@ -152,10 +148,6 @@ FormButtonGroup.Sticky = ({ align, ...props }) => {
       </div>
     </StickyBox>
   )
-}
-
-FormButtonGroup.Sticky.defaultProps = {
-  align: 'left',
 }
 
 export default FormButtonGroup

--- a/packages/components/src/form-grid/index.tsx
+++ b/packages/components/src/form-grid/index.tsx
@@ -81,17 +81,13 @@ const InternalFormGrid = observer(
 )
 
 export const GridColumn: React.FC<React.PropsWithChildren<IGridColumnProps>> =
-  observer(({ gridSpan, children, ...props }) => {
+  observer(({ gridSpan = 1, children, ...props }) => {
     return (
       <div {...props} style={props.style} data-grid-span={gridSpan}>
         {children}
       </div>
     )
   })
-
-GridColumn.defaultProps = {
-  gridSpan: 1,
-}
 
 export const FormGrid = Object.assign(InternalFormGrid, {
   createFormGrid,

--- a/packages/components/src/form-layout/index.tsx
+++ b/packages/components/src/form-layout/index.tsx
@@ -65,7 +65,14 @@ export const FormLayout: React.FC<React.PropsWithChildren<IFormLayoutProps>> & {
   useFormLayout: () => IFormLayoutContext
   useFormDeepLayout: () => IFormLayoutContext
   useFormShallowLayout: () => IFormLayoutContext
-} = ({ shallow, children, prefixCls, className, style, ...otherProps }) => {
+} = ({
+  shallow = true,
+  children,
+  prefixCls,
+  className,
+  style,
+  ...otherProps
+}) => {
   const { ref, props } = useResponsiveFormLayout(otherProps)
   const deepLayout = useFormDeepLayout()
   const formPrefixCls = usePrefixCls('form', { prefixCls })
@@ -106,10 +113,6 @@ export const FormLayout: React.FC<React.PropsWithChildren<IFormLayoutProps>> & {
       {renderChildren()}
     </div>
   )
-}
-
-FormLayout.defaultProps = {
-  shallow: true,
 }
 
 FormLayout.useFormDeepLayout = useFormDeepLayout

--- a/packages/components/src/form/index.tsx
+++ b/packages/components/src/form/index.tsx
@@ -23,7 +23,7 @@ export interface FormProps extends IFormLayoutProps {
 
 export const Form: React.FC<React.PropsWithChildren<FormProps>> = ({
   form,
-  component,
+  component = 'form',
   onAutoSubmit,
   onAutoSubmitFailed,
   previewTextPlaceholder,
@@ -53,10 +53,6 @@ export const Form: React.FC<React.PropsWithChildren<FormProps>> = ({
     return <FormProvider form={form}>{renderContent(form)}</FormProvider>
   if (!top) throw new Error('must pass form instance by createForm')
   return renderContent(top)
-}
-
-Form.defaultProps = {
-  component: 'form',
 }
 
 export default Form

--- a/packages/components/src/select-table/index.tsx
+++ b/packages/components/src/select-table/index.tsx
@@ -147,11 +147,11 @@ const addPrimaryKey = (dataSource, rowKey, primaryKey) =>
 
 const InternalSelectTable: ReactFC<ISelectTableProps> = observer((props) => {
   const {
-    mode,
+    mode = 'multiple',
     dataSource: propsDataSource,
     optionAsValue,
-    valueType,
-    showSearch,
+    valueType = 'all',
+    showSearch = false,
     filterOption,
     filterSort,
     onSearch,
@@ -160,7 +160,7 @@ const InternalSelectTable: ReactFC<ISelectTableProps> = observer((props) => {
     value,
     onChange,
     rowSelection,
-    primaryKey: rowKey,
+    primaryKey: rowKey = 'key',
     ...otherTableProps
   } = props
   const prefixCls = usePrefixCls('formily-select-table', props)
@@ -421,12 +421,5 @@ const TableColumn: React.FC<
 export const SelectTable = Object.assign(InternalSelectTable, {
   Column: TableColumn,
 })
-
-SelectTable.defaultProps = {
-  showSearch: false,
-  valueType: 'all',
-  primaryKey: 'key',
-  mode: 'multiple',
-}
 
 export default SelectTable

--- a/packages/components/src/transfer/index.tsx
+++ b/packages/components/src/transfer/index.tsx
@@ -2,6 +2,7 @@ import { isVoidField } from '@formily/core'
 import { connect, mapProps } from '@formily/react'
 import { Transfer as AntdTransfer } from 'antd'
 
+const renderTitle = (item) => item.title ?? null
 export const Transfer = connect(
   AntdTransfer,
   mapProps(
@@ -12,6 +13,7 @@ export const Transfer = connect(
       if (isVoidField(field)) return props
       return {
         ...props,
+        render: props.render || renderTitle,
         dataSource:
           field.dataSource?.map((item) => {
             return {
@@ -24,9 +26,5 @@ export const Transfer = connect(
     }
   )
 )
-
-Transfer.defaultProps = {
-  render: (item) => item.title ?? null,
-}
 
 export default Transfer


### PR DESCRIPTION
Form 组件 component 无法获取到 form, 造成渲染失败

https://github.com/alibaba/formily/pull/4262
https://github.com/alibaba/formily/issues/4254

_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/master/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `master`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

修复在 React 19 环境中 defaultProps 失效问题, 这是 19 的一个 BreakChange, 将  defaultProps 替换为ES6 参数默认赋值;  

React 19 Upgrade Guide [Removed: propTypes and defaultProps for functions](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops)

https://codesandbox.io/p/sandbox/tgnf4j
